### PR TITLE
cuda-libraries-static v13.1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,10 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-2
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-2
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.0.2" %}
+{% set version = "13.1.0" %}
 
 package:
   name: cuda-libraries-static
@@ -14,19 +14,19 @@ build:
 
 requirements:
   run:
-    - cuda-cudart-static 13.0.96
-    - cuda-culibos-static 13.0.85    # [linux]
-    - cuda-nvrtc-static 13.0.88
-    - libcublas-static 13.1.0.3      # [linux]
-    - libcufft-static 12.0.0.61      # [linux]
-    - libcufile-static 1.15.1.6       # [linux]
-    - libcurand-static 10.4.0.35    # [linux]
-    - libcusolver-static 12.0.4.66  # [linux]
-    - libcusparse-static 12.6.3.3  # [linux]
-    - libnpp-static 13.0.1.2         # [linux]
-    - libnvfatbin-static 13.0.85
-    - libnvjitlink-static 13.0.88
-    - libnvjpeg-static 13.0.1.86     # [linux]
+    - cuda-cudart-static 13.1.80
+    - cuda-culibos-static 13.1.68    # [linux]
+    - cuda-nvrtc-static 13.1.80
+    - libcublas-static 13.2.0.9      # [linux]
+    - libcufft-static 12.1.0.31      # [linux]
+    - libcufile-static 1.16.0.49       # [linux]
+    - libcurand-static 10.4.1.34    # [linux]
+    - libcusolver-static 12.0.7.41  # [linux]
+    - libcusparse-static 12.7.2.19  # [linux]
+    - libnpp-static 13.0.2.21         # [linux]
+    - libnvfatbin-static 13.1.80
+    - libnvjitlink-static 13.1.80
+    - libnvjpeg-static 13.0.2.28     # [linux]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.1.0" %}
+{% set version = "13.1.1" %}
 
 package:
   name: cuda-libraries-static
@@ -15,18 +15,18 @@ build:
 requirements:
   run:
     - cuda-cudart-static 13.1.80
-    - cuda-culibos-static 13.1.68    # [linux]
-    - cuda-nvrtc-static 13.1.80
-    - libcublas-static 13.2.0.9      # [linux]
-    - libcufft-static 12.1.0.31      # [linux]
-    - libcufile-static 1.16.0.49       # [linux]
-    - libcurand-static 10.4.1.34    # [linux]
-    - libcusolver-static 12.0.7.41  # [linux]
-    - libcusparse-static 12.7.2.19  # [linux]
-    - libnpp-static 13.0.2.21         # [linux]
-    - libnvfatbin-static 13.1.80
-    - libnvjitlink-static 13.1.80
-    - libnvjpeg-static 13.0.2.28     # [linux]
+    - cuda-culibos-static 13.1.115    # [linux]
+    - cuda-nvrtc-static 13.1.115
+    - libcublas-static 13.2.1.1      # [linux]
+    - libcufft-static 12.1.0.78      # [linux]
+    - libcufile-static 1.16.1.26       # [linux]
+    - libcurand-static 10.4.1.81    # [linux]
+    - libcusolver-static 12.0.9.81  # [linux]
+    - libcusparse-static 12.7.3.1  # [linux]
+    - libnpp-static 13.0.3.3         # [linux]
+    - libnvfatbin-static 13.1.115
+    - libnvjitlink-static 13.1.115
+    - libnvjpeg-static 13.0.3.75     # [linux]
 
 test:
   commands:


### PR DESCRIPTION
cuda-libraries-static 13.1.1

**Destination channel:** defaults

### Links

- [PKG-12035](https://anaconda.atlassian.net/browse/PKG-12035) 

### Explanation of changes:

- CUDA 13.1 release

### Notes

- Successful PBP run: https://package-build.anaconda.com/v1/graph/849cf2e9-2fec-4b9d-a382-da0a85775a80

[PKG-12035]: https://anaconda.atlassian.net/browse/PKG-12035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ