### PR TITLE
cuda-libraries-static v12.9.1

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "12.9.0" %}
+{% set version = "12.9.1" %}
 
 package:
   name: cuda-libraries-static
@@ -14,18 +14,18 @@ build:
 
 requirements:
   run:
-    - cuda-cudart-static 12.9.37
-    - cuda-nvrtc-static 12.9.41
-    - libcublas-static 12.9.0.13      # [linux]
-    - libcufft-static 11.4.0.6      # [linux]
-    - libcufile-static 1.14.0.30       # [linux]
+    - cuda-cudart-static 12.9.79
+    - cuda-nvrtc-static 12.9.86
+    - libcublas-static 12.9.1.4      # [linux]
+    - libcufft-static 11.4.1.4      # [linux]
+    - libcufile-static 1.14.1.1       # [linux]
     - libcurand-static 10.3.10.19    # [linux]
-    - libcusolver-static 11.7.4.40  # [linux]
-    - libcusparse-static 12.5.9.5  # [linux]
-    - libnpp-static 12.4.0.27         # [linux]
-    - libnvfatbin-static 12.9.19
-    - libnvjitlink-static 12.9.41
-    - libnvjpeg-static 12.4.0.16     # [linux]
+    - libcusolver-static 11.7.5.82  # [linux]
+    - libcusparse-static 12.5.10.65  # [linux]
+    - libnpp-static 12.4.1.87         # [linux]
+    - libnvfatbin-static 12.9.82
+    - libnvjitlink-static 12.9.86
+    - libnvjpeg-static 12.4.0.76     # [linux]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "12.8.1" %}
+{% set version = "12.9.0" %}
 
 package:
   name: cuda-libraries-static
@@ -14,18 +14,18 @@ build:
 
 requirements:
   run:
-    - cuda-cudart-static 12.8.90
-    - cuda-nvrtc-static 12.8.93
-    - libcublas-static 12.8.4.1      # [linux]
-    - libcufft-static 11.3.3.83      # [linux]
-    - libcufile-static 1.13.1.3       # [linux]
-    - libcurand-static 10.3.9.90    # [linux]
-    - libcusolver-static 11.7.3.90  # [linux]
-    - libcusparse-static 12.5.8.93  # [linux]
-    - libnpp-static 12.3.3.100         # [linux]
-    - libnvfatbin-static 12.8.90
-    - libnvjitlink-static 12.8.93
-    - libnvjpeg-static 12.3.5.92     # [linux]
+    - cuda-cudart-static 12.9.37
+    - cuda-nvrtc-static 12.9.41
+    - libcublas-static 12.9.0.13      # [linux]
+    - libcufft-static 11.4.0.6      # [linux]
+    - libcufile-static 1.14.0.30       # [linux]
+    - libcurand-static 10.3.10.19    # [linux]
+    - libcusolver-static 11.7.4.40  # [linux]
+    - libcusparse-static 12.5.9.5  # [linux]
+    - libnpp-static 12.4.0.27         # [linux]
+    - libnvfatbin-static 12.9.19
+    - libnvjitlink-static 12.9.41
+    - libnvjpeg-static 12.4.0.16     # [linux]
 
 test:
   commands:


### PR DESCRIPTION
cuda-libraries-static 12.9.1

**Destination channel:** defaults

### Links

- [PKG-12804](https://anaconda.atlassian.net/browse/PKG-12804) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's conda-forge/cuda-libraries-static-feedstock@d68f0417a71e743d12830167b309dff3c08f49b3 commit.
- This is a meta-package


[PKG-12804]: https://anaconda.atlassian.net/browse/PKG-12804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ